### PR TITLE
Alioth is gone, use address it was redirecting to

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -16,7 +16,7 @@ usually deliver some additional modules that are not in the corelist.
 For Debian you can use the following website to check which module is
 included in a Debian release and in which version:<br>
 <ul>
-    <li><a href="http://pkg-perl.alioth.debian.org/cpan2deb/">Debian</a>
+    <li><a href="http://deb.perl.it/debian/cpan-deb/">Debian</a>
     <i>(Note that this website needs JavaScript.)</i></li>
     <li>Windows
     <ul>


### PR DESCRIPTION
The machine which hosted Alioth has been removed¹, but thankfully this was just a redirection.
¹ https://lists.debian.org/debian-devel-announce/2018/06/msg00001.html